### PR TITLE
Puppet4: file mode specification must be a string, not 'Fixnum'

### DIFF
--- a/manifests/libvirt/storage.pp
+++ b/manifests/libvirt/storage.pp
@@ -20,7 +20,7 @@ class katellovirt::libvirt::storage {
     content => $content,
     owner   => 'root',
     group   => 'root',
-    mode    => 0600,
+    mode    => '0600',
     replace => false,
   } ->
   exec { "virsh-pool-define-${pool_name}":


### PR DESCRIPTION
Fix file mode specification must be a string, not 'Fixnum'
