### PR TITLE
Fix: Passing port to firewall is deprecated... Use dport and/or sport instead

### DIFF
--- a/manifests/firewall/katello.pp
+++ b/manifests/firewall/katello.pp
@@ -1,6 +1,6 @@
 class katellovirt::firewall::katello {
   firewall { '200 accept AMQP TCP':
-    port   => 5671,
+    dport  => 5671,
     proto  => tcp,
     action => accept,
   }

--- a/manifests/firewall/pre.pp
+++ b/manifests/firewall/pre.pp
@@ -19,7 +19,7 @@ class katellovirt::firewall::pre {
     action  => 'accept',
   }->
   firewall { '003 accept ssh':
-    port   => 22,
+    dport  => 22,
     proto  => tcp,
     action => accept,
   }

--- a/manifests/firewall/provisioning.pp
+++ b/manifests/firewall/provisioning.pp
@@ -1,60 +1,60 @@
 class katellovirt::firewall::provisioning {
   firewall { '100 accept http/https':
-    port   => [80, 443],
+    dport  => [80, 443],
     proto  => tcp,
     action => accept,
   }
 
   firewall { '105 accept foreman proxy':
-    port   => 9090,
+    dport  => 9090,
     proto  => tcp,
     action => accept,
   }
 
   firewall { '110 accept puppet':
-    port   => 8140,
+    dport  => 8140,
     proto  => tcp,
     action => accept,
   }
 
   firewall { '120 accept DHCP':
-    port   => [67, 68],
+    dport  => [67, 68],
     proto  => udp,
     action => accept,
   }
 
   firewall { '125 accept TFTP':
-    port   => 69,
+    dport  => 69,
     proto  => udp,
     action => accept,
   }
 
   firewall { '130 accept DNS TCP':
-    port   => 53,
+    dport  => 53,
     proto  => tcp,
     action => accept,
   }
 
   firewall { '131 accept DNS UDP':
-    port   => 53,
+    dport  => 53,
     proto  => udp,
     action => accept,
   }
 
   firewall { '140 accept libvirt TCP':
-    port   => 16509,
+    dport  => 16509,
     proto  => tcp,
     action => accept,
   }
 
   firewall { '150 accept libvirt VNC':
-    port   => '5910-5919',
+    dport  => '5910-5919',
     proto  => tcp,
     action => accept,
   }
 
   firewall { '151 accept websocket VNC':
-    port   => '5900-5909',
+    dport  => '5900-5909',
     proto  => tcp,
     action => accept,
   }


### PR DESCRIPTION
Fixes multiple warnings

```
Info: Loading facts
Info: Loading facts
Info: Loading facts
Warning: Config file /etc/puppet/hiera.yaml not found, using Hiera defaults
Notice: Compiled catalog <FQDN> in environment production in 0.67 seconds
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Warning: Passing port to firewall is deprecated and will be removed. Use dport and/or sport instead.
Info: Applying configuration version '1473769873'
Notice: Finished catalog run in 1.26 seconds
```
